### PR TITLE
Update conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -186,16 +186,12 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
-
-    'utf8extra': r'''
-        \usepackage{CJKutf8}
-        \DeclareUnicodeCharacter{00A0}{\nobreakspace}
-        \DeclareUnicodeCharacter{2203}{\ensuremath{\exists}}
-        \DeclareUnicodeCharacter{2200}{\ensuremath{\forall}}
-        \DeclareUnicodeCharacter{2286}{\ensuremath{\subseteq}}
-        \DeclareUnicodeCharacter{2713}{x}
-        \DeclareUnicodeCharacter{27FA}{\ensuremath{\Longleftrightarrow}}
-    ''',
+'preamble': '''
+\\hypersetup{unicode=true}
+\\usepackage{CJKutf8}
+\\begin{CJK}{UTF8}{gbsn}
+\\AtEndDocument{\\end{CJK}}
+''',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
经报告issue（https://github.com/rtfd/readthedocs.org/issues/621 ），RTFD已在服务器上安装文鼎简宋、简楷、繁明、繁楷四个开源LaTeX字体。
我创建了一个临时repo测试了一下，RTFD似乎仍然会显示PDF构建失败，但实际上能够正确生成中文PDF。

现修正Latex_elements。这样一来RTFD应该可以自动生成中文PDF文件。
